### PR TITLE
Pass provider to retireveAndDecrypt instead of ConditionContext

### DIFF
--- a/src/characters/universal-bob.ts
+++ b/src/characters/universal-bob.ts
@@ -6,13 +6,13 @@ import {
   SecretKey,
   Signer,
 } from '@nucypher/nucypher-core';
+import { ethers } from 'ethers';
 
 import { Keyring } from '../keyring';
 import { PolicyMessageKit } from '../kits/message';
 import { RetrievalResult } from '../kits/retrieval';
 import { ConditionSet } from '../policies/conditions';
 import { base64ToU8Receiver, u8ToBase64Replacer, zip } from '../utils';
-import { Web3Provider } from '../web3';
 
 import { Porter } from './porter';
 
@@ -56,7 +56,7 @@ export class tDecDecrypter {
 
   public async retrieveAndDecrypt(
     messageKits: readonly MessageKit[],
-    provider: Web3Provider
+    provider: ethers.providers.Web3Provider
   ): Promise<readonly Uint8Array[]> {
     const policyMessageKits = await this.retrieve(messageKits, provider);
 
@@ -83,7 +83,7 @@ export class tDecDecrypter {
 
   public async retrieve(
     messageKits: readonly MessageKit[],
-    provider: Web3Provider
+    provider: ethers.providers.Web3Provider
   ): Promise<readonly PolicyMessageKit[]> {
     const treasureMap = this.encryptedTreasureMap.decrypt(
       this.keyring.secretKey,

--- a/src/policies/conditions.ts
+++ b/src/policies/conditions.ts
@@ -1,5 +1,5 @@
 import { Conditions as WASMConditions } from '@nucypher/nucypher-core';
-import { utils as ethersUtils } from 'ethers';
+import { ethers, utils as ethersUtils } from 'ethers';
 import Joi, { ValidationError } from 'joi';
 
 import { Eip712TypedData, FormattedTypedData, Web3Provider } from '../web3';
@@ -82,8 +82,11 @@ export class ConditionSet {
     return new WASMConditions(this.toJson());
   }
 
-  public buildContext(provider: Web3Provider): ConditionContext {
-    return new ConditionContext(this.toWASMConditions(), provider);
+  public buildContext(
+    provider: ethers.providers.Web3Provider
+  ): ConditionContext {
+    const web3Provider = Web3Provider.fromEthersWeb3Provider(provider);
+    return new ConditionContext(this.toWASMConditions(), web3Provider);
   }
 }
 

--- a/test/integration/conditions.test.ts
+++ b/test/integration/conditions.test.ts
@@ -254,7 +254,10 @@ describe('condition context', () => {
     });
     const conditionSet = new ConditionSet([rpcCondition]);
 
-    const conditionContext = new ConditionContext(conditionSet, web3Provider);
+    const conditionContext = new ConditionContext(
+      conditionSet.toWASMConditions(),
+      web3Provider
+    );
     const asJson = await conditionContext.toJson();
     expect(asJson).toBeDefined();
   });

--- a/test/unit/strategy.test.ts
+++ b/test/unit/strategy.test.ts
@@ -14,6 +14,7 @@ import {
 } from '../../src';
 import { Ursula } from '../../src/characters/porter';
 import { fromBase64, toBytes } from '../../src/utils';
+import { Web3Provider } from '../../src/web3';
 import {
   mockEncryptTreasureMap,
   mockGenerateKFrags,
@@ -217,10 +218,9 @@ describe('Deployed Strategy', () => {
       encryptedMessageKit.capsule
     );
 
-    const conditionContext = conditions.buildContext(bobProvider);
     const decryptedMessage = await decrypter.retrieveAndDecrypt(
       [encryptedMessageKit],
-      conditionContext
+      Web3Provider.fromEthersWeb3Provider(bobProvider)
     );
     expect(getUrsulasSpy2).toHaveBeenCalled();
     expect(retrieveCFragsSpy).toHaveBeenCalled();

--- a/test/unit/strategy.test.ts
+++ b/test/unit/strategy.test.ts
@@ -14,7 +14,6 @@ import {
 } from '../../src';
 import { Ursula } from '../../src/characters/porter';
 import { fromBase64, toBytes } from '../../src/utils';
-import { Web3Provider } from '../../src/web3';
 import {
   mockEncryptTreasureMap,
   mockGenerateKFrags,
@@ -220,7 +219,7 @@ describe('Deployed Strategy', () => {
 
     const decryptedMessage = await decrypter.retrieveAndDecrypt(
       [encryptedMessageKit],
-      Web3Provider.fromEthersWeb3Provider(bobProvider)
+      bobProvider
     );
     expect(getUrsulasSpy2).toHaveBeenCalled();
     expect(retrieveCFragsSpy).toHaveBeenCalled();


### PR DESCRIPTION
When calling `tDecDecrypter.retrieveAndDecrypt()` the current api takes in `messageKits` and `conditionContext`. The problem with this is that `messageKits` already contains `conditions` and there is no guarantee that `conditionContext` contains the same condition set. 

What I think the real intent here is to check if any of the `condition`(s) include a `:userAddress` and therefore require a signature. This can be done just by passing a `provider` to this method.

This is a proposal of how this could be accomplished, but a more thorough rework of `ConditionContext` may be warranted to be cleaner